### PR TITLE
Fix first time build failure

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "rm -r ../backend/client/build && react-scripts build && mv ./build ../backend/client",
+    "build": "rm -fr ../backend/client/build && react-scripts build && mv ./build ../backend/client",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Because `rm` did not have a `f` arg, it would fail when the build
directory didn't already exist.  This caused builds to fail for all
fresh checkouts.