### PR TITLE
Set app name in manifest

### DIFF
--- a/react-app/public/manifest.json
+++ b/react-app/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "WeatherVis",
+  "name": "WeatherVis",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
This value gets used as the default name in things like iOS home screen shortcuts.